### PR TITLE
Better-letter-drag

### DIFF
--- a/scripts/canvas.js
+++ b/scripts/canvas.js
@@ -344,7 +344,7 @@ function updateTile(tile) {
 	}
 	canvas.ctx.font = fontSize + "px Eurostile";
 	canvas.ctx.textAlign = "center";
-	canvas.ctx.fillText(tile.letter, pixelX + (tileWidth / 2), pixelY + fontSize);
+	canvas.ctx.fillText(tile.letter || "", pixelX + (tileWidth / 2), pixelY + fontSize);
 
 	// draw the points on the tile if size allows
 	if (squareWidth >= 35 && !tile.blank) {
@@ -355,6 +355,7 @@ function updateTile(tile) {
 	}
 }
 
+// draw loop
 // this function is run to draw each frame
 function updateDisplay() {
 	clearCanvas();


### PR DESCRIPTION
Increase the space left when dragging a letter in the bank to be, on a normal screen size, the same width as a tile. Fix the 'null' text when dragging a blank tile.